### PR TITLE
Handle empty / null list mapping on creation

### DIFF
--- a/Mapping.php
+++ b/Mapping.php
@@ -114,6 +114,9 @@ class Mapping extends Object
 
         if ($this->multiple) {
             $result = new ArrayObject();
+            if ($sourceValue === null) {
+                return $result;
+            }
             foreach ($sourceValue as $key => $frame) {
                 if (!is_array($frame)) {
                     throw new InvalidParamException("Source value for the embedded should be an array.");


### PR DESCRIPTION
When creating the value of a embedded list where the sourceValue is null And createFromNull = false it should return the empty ArrayObject and not try to step through non-existant values.
